### PR TITLE
A couple fixes for el6/py2.6.

### DIFF
--- a/appstream/component.py
+++ b/appstream/component.py
@@ -20,6 +20,13 @@
 
 import xml.etree.ElementTree as ET
 
+try:
+    # Py2.7 and newer
+    from xml.etree import ParseError as StdlibParseError
+except ImportError:
+    # Py2.6 and older
+    from xml.parsers.expat import ExpatError as StdlibParseError
+
 from errors import ParseError, ValidationError
 
 def _join_lines(txt):
@@ -250,7 +257,7 @@ class Component(object):
         # parse tree
         try:
             root = ET.fromstring(xml_data)
-        except ET.ParseError as e:
+        except StdlibParseError as e:
             raise ParseError(str(e))
 
         # get type

--- a/appstream/store.py
+++ b/appstream/store.py
@@ -42,8 +42,11 @@ class Store(object):
 
         # save compressed file
         xml = self.to_xml()
-        with gzip.open(filename, 'wb') as f:
+        f = gzip.open(filename, 'wb')
+        try:
             f.write(unicode(xml).encode('utf-8'))
+        finally:
+            f.close()
 
     def get_component(self, app_id):
         """ Finds an application from the store """

--- a/test.py
+++ b/test.py
@@ -18,6 +18,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA
 
+from __future__ import print_function
+
 import appstream
 
 def main():
@@ -132,7 +134,7 @@ def main():
     app = appstream.Component()
     app.parse(data)
     store.add(app)
-    print store.to_xml()
+    print(store.to_xml().encode('utf-8'))
 
     store.to_file('/tmp/firmware.xml.gz')
 


### PR DESCRIPTION
- 43870ed - Different parsing errors on py2.6 and py2.7.
- bc0139e - That gzip lib doesn't provide a context manager on py2.6.
- 67b287c - Encode stdout output explicitly for py2.6.