### PR TITLE
Get everything working on py3.4 as well, for completeness....

### DIFF
--- a/appstream/__init__.py
+++ b/appstream/__init__.py
@@ -18,9 +18,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA
 
-from store import Store
-from component import Component
-from component import Checksum
-from component import Provide
-from component import Release
-from errors import ParseError, ValidationError
+from appstream.store import Store
+from appstream.component import Component
+from appstream.component import Checksum
+from appstream.component import Provide
+from appstream.component import Release
+from appstream.errors import ParseError, ValidationError

--- a/appstream/component.py
+++ b/appstream/component.py
@@ -27,7 +27,7 @@ except ImportError:
     # Py2.6 and older
     from xml.parsers.expat import ExpatError as StdlibParseError
 
-from errors import ParseError, ValidationError
+from appstream.errors import ParseError, ValidationError
 
 def _join_lines(txt):
     """ Remove whitespace from XML input """

--- a/appstream/store.py
+++ b/appstream/store.py
@@ -44,7 +44,7 @@ class Store(object):
         xml = self.to_xml()
         f = gzip.open(filename, 'wb')
         try:
-            f.write(unicode(xml).encode('utf-8'))
+            f.write(xml.encode('utf-8'))
         finally:
             f.close()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = {py26,py27,py34}
+downloadcache = {toxworkdir}/_download/
+
+[testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py34: python3.4
+sitepackages = False
+commands =
+    python test.py {posargs}


### PR DESCRIPTION
Also, this adds a `tox.ini` file which allows testing across multiple python
language versions.

Just run

```bash
$ tox
```