### PR TITLE
Add support for bundle tag.

### DIFF
--- a/appstream/component.py
+++ b/appstream/component.py
@@ -369,8 +369,13 @@ class Component(object):
         if self.description:
             xml += '    <description>%s</description>\n' % self.description
         if self.bundle:
-            xml += '    <bundle type="%s" runtime="%s" sdk="%s">%s</bundle>\n' % \
-                   (self.bundle['type'], self.bundle['runtime'], self.bundle['sdk'], self.bundle['value'])
+            xml += '    <bundle type="%(type)" %(runtime) %(sdk)>%(value)</bundle>\n' % \
+                   {
+                       'type': self.bundle['type'],
+                       'runtime': ('runtime="%s"' % self.bundle['runtime']) if self.bundle['runtime'] != 'unknown' else "",
+                       'sdk': ('sdk="%s"' % self.bundle['sdk']) if self.bundle['sdk'] != 'unknown' else "",
+                       'value': self.bundle['value']
+                   }
         for key in self.urls:
             xml += '    <url type="%s">%s</url>\n' % (key, self.urls[key])
         for key in self.icons:

--- a/appstream/component.py
+++ b/appstream/component.py
@@ -350,6 +350,7 @@ class Component(object):
         self.keywords = []
         self.categories = []
         self.custom = {}
+        self.bundle = {}
 
     def to_xml(self):
         xml = '  <component type="firmware">\n'
@@ -367,6 +368,9 @@ class Component(object):
             xml += '    <project_license>%s</project_license>\n' % self.project_license
         if self.description:
             xml += '    <description>%s</description>\n' % self.description
+        if self.bundle:
+            xml += '    <bundle type="%s" runtime="%s" sdk="%s">%s</bundle>\n' % \
+                   (self.bundle['type'], self.bundle['runtime'], self.bundle['sdk'], self.bundle['value'])
         for key in self.urls:
             xml += '    <url type="%s">%s</url>\n' % (key, self.urls[key])
         for key in self.icons:
@@ -655,7 +659,22 @@ class Component(object):
                     key = c1.attrib['type']
                 self.urls[key] = c1.text
 
+            # <icon>
             elif c1.tag == 'icon':
                 key = c1.attrib.pop('type', 'unknown')
                 c1.attrib['value'] = c1.text
                 self.icons[key] = self.icons.get(key, []) + [c1.attrib]
+
+            # <bundle>
+            elif c1.tag == 'bundle':
+                type = c1.attrib.pop('type', 'unknown')
+                runtime = c1.attrib.pop('runtime', 'unknown')
+                sdk = c1.attrib.pop('sdk', 'unknown')
+                value = c1.text
+                self.bundle = {
+                    'type': type,
+                    'runtime': runtime,
+                    'sdk': sdk,
+                    'value': value
+                }
+


### PR DESCRIPTION
I'm currently using python-appstream with flatpak and the bundle tag is a requirement for me to get the flatpak ref and other details.

For example:
`<bundle type="flatpak" runtime="org.gnome.Platform/x86_64/3.26" sdk="org.gnome.Sdk/x86_64/3.26">app/org.gnome.Books/x86_64/stable</bundle>`

Let me know what you think and if there's any changes I should make or any other requirements I missed/need to fulfill. 